### PR TITLE
env var support for application identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,8 @@ Supported configurations:
     * `application_identity` (`string`) - The name or ID of the "Developer ID Application"
       certificate to use to sign applications. This accepts any valid value for the `-s`
       flag for the `codesign` binary on macOS. See `man codesign` for detailed
-      documentation on accepted values.
+      documentation on accepted values. If this isn't set, we'll attempt to read
+      the `AC_APPLICATION_IDENTITY` environment variable as a default.
 
     * `entitlements_file` (`string` _optional_) - The full path to a plist format .entitlements file, used for the `--entitlements` argument to `codesign`
 

--- a/cmd/gon/main.go
+++ b/cmd/gon/main.go
@@ -181,6 +181,19 @@ func realMain() int {
 	if len(cfg.Source) > 0 {
 		if cfg.Sign != nil {
 			// Perform codesigning
+			if cfg.Sign.ApplicationIdentity == "" {
+				applicationIdentity, ok := os.LookupEnv("AC_APPLICATION_IDENTITY")
+				if !ok {
+					color.New(color.Bold, color.FgRed).Fprintf(os.Stdout, "❗️ No application_identity provided\n")
+					color.New(color.FgRed).Fprintf(os.Stdout,
+						"An application identity must be specified in the `sign` block or\n"+
+							"it must exist in the environment as AC_APPLICATION_IDENTITY,\n"+
+							"otherwise we won't be able to sign your files.\n")
+					return 1
+				}
+
+				cfg.Sign.ApplicationIdentity = applicationIdentity
+			}
 			color.New(color.Bold).Fprintf(os.Stdout, "==> %s  Signing files...\n", iconSign)
 			err = sign.Sign(context.Background(), &sign.Options{
 				Files:        cfg.Source,


### PR DESCRIPTION
Allows application identity to be kept secret by providing for an environment variable `AC_APPLICATION_IDENTITY`.