### PR TITLE
chore: update to MacOS 13

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
   build:
     needs: [tag]
     name: build
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Update runner to macos-13 as 12 is no longer supported